### PR TITLE
Fix st.w storing only half-word

### DIFF
--- a/data/languages/v850_load_store.sinc
+++ b/data/languages/v850_load_store.sinc
@@ -113,7 +113,7 @@
 :st.w R2731, disp23[R0004] is op0515=0x03C & R0004; R2731 & op2126 & op1620=0xF; s3247
 [ disp23 = (s3247 << 7) | (op2126 << 1); ] {
 	local addr:4 = disp23 + R0004;
-	*:2 addr = R2731 : 2;
+	*:4 addr = R2731;
 }
 # LD.BU disp23[reg1], reg3
 :ld.bu disp23[R0004], R2731 is op0515=0x03D & R0004; R2731 & op2026 & op1619=5; s3247


### PR DESCRIPTION
One of the two st.w variants would only store 2 bytes instead of 4. This would lead to weird `SUB42()` in the decompilation.

Same bug is present upstream: https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Processors/V850/data/languages/Instructions/Load_Store.sinc#L210

![2024-04-30-130752_641x920_scrot](https://github.com/esaulenka/ghidra_v850/assets/1314752/c8f29d9a-efae-4891-a7d9-17c7976f4e5d)
