### PR TITLE
Fix JMP disp32[reg1] dereference

### DIFF
--- a/data/languages/v850_common.sinc
+++ b/data/languages/v850_common.sinc
@@ -247,7 +247,7 @@ addr22: rel is s0005; op1631 & op1616=0
 addr32: rel is op1731 & op1616=0; op3247
 [ rel = ((op3247 << 16) | op1731 << 1) + inst_start; ] { export *:4 rel; }
 addr32abs: rel is op1731 & op1616=0; op3247
-[ rel = ((op3247 << 16) | op1731 << 1); ] { export *:4 rel; }
+[ rel = ((op3247 << 16) | op1731 << 1); ] { export *[const]:4 rel; }
 
 @if defined (V850E3)
 addr17b: rel is s0404 ; op1731 & op1616=1


### PR DESCRIPTION
`addr32abs` has a dereference causing it to hold the value at the address pointed by `disp32` instead of `disp32` itself. This would break jump tables.

```
# JMP disp32[reg1]
:jmp addr32abs[R0004] is op0515=0x037 & R0004; op1616=0 ... & addr32abs {
	local addr = addr32abs + R0004;
	goto [addr];
}
```